### PR TITLE
Phase 5: Feature engineering

### DIFF
--- a/docs/decisions/007-feature-engineering-policy.md
+++ b/docs/decisions/007-feature-engineering-policy.md
@@ -1,0 +1,60 @@
+# ADR-007: Feature engineering policy — no leakage
+
+## Status
+
+Accepted — Phase 5
+
+## Context
+
+The IPL match prediction model needs input features (team form, head-to-head record, venue effects, etc.) computed for every match in `gold.fact_matches`. The hardest correctness constraint in feature engineering for predictive ML is **temporal leakage**: a feature that uses information from the future, including from the match it's labeling.
+
+Without strict policy, leakage creeps in via three patterns:
+
+1. **Aggregating across all matches** — `AVG(...) OVER (PARTITION BY team)` includes the current match's outcome in its own feature.
+2. **Closed-interval predicates** — `WHERE other.match_date <= current.match_date` accidentally includes same-day matches, which in a tournament setting can mean the model sees today's results.
+3. **Joining to gold tables that don't carry temporal context** — e.g. computing player career stats from `dim_players` then joining as a feature, where `dim_players` aggregates over all time including post-match.
+
+A model trained on leaked features achieves unrealistic test accuracy, then collapses in production. This is the most common failure mode in ML portfolios.
+
+## Decision
+
+All features for match M (with `match_date = D`) are computed using only rows from `gold.fact_matches` where `match_date < D` — strictly before, never on or after.
+
+We enforce this at three levels:
+
+**1. Convention in SQL.** Every feature model uses an as-of correlated subquery or LATERAL join with the predicate `h.match_date < m.match_date`. The strictly-less-than is mandatory.
+
+**2. dbt tests.** A custom dbt test in `warehouse/tests/` verifies that for any row in `feature_set`, no source row contributing to its features has `match_date >= match_date_of_target`.
+
+**3. Walk-forward splits.** Train, validation, and holdout sets are split chronologically:
+- Train: 2022 season
+- Validation: first half of 2023
+- Holdout: second half of 2023 + all of 2024
+
+This ensures the model is evaluated on data strictly after its training data, mimicking production use.
+
+## Consequences
+
+**Positive:**
+- Test-set metrics in Phase 6 reflect realistic predictive accuracy
+- The pipeline can be deployed to production without subtle bugs
+- Reviewers reading the codebase see explicit leakage guards
+
+**Negative:**
+- Feature SQL is more verbose (correlated subqueries instead of window functions)
+- Earliest matches in the dataset have NaN features (no prior matches to aggregate)
+- Some intuitively-useful features become hard to compute correctly (e.g. "this player's form" requires per-player as-of joins, which we defer to a later iteration)
+
+## Alternatives considered
+
+**Alt 1: Compute features once at predict time.** Rejected — defeats the purpose of having a feature store, and recreates the same leakage risk.
+
+**Alt 2: Use window functions with `RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING`.** Rejected — works in some dialects but Postgres's `RANGE` semantics on dates can include same-day rows, creating subtle leakage.
+
+**Alt 3: Compute features in Python at training time.** Rejected — moves the discipline out of the warehouse and makes it harder to test, harder to inspect, and harder to reuse.
+
+## References
+
+- [Andrej Karpathy on training-test leakage](https://karpathy.github.io/2019/04/25/recipe/)
+- [dbt docs: Tests](https://docs.getdbt.com/docs/build/tests)
+- ADR-004: time-based splits, walk-forward eval, calibration mandatory

--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -24,6 +24,9 @@ models:
     gold:
       +schema: gold
       +materialized: view
+    features:
+      +schema: features
+      +materialized: view
 
 seeds:
   ipl_warehouse:

--- a/warehouse/models/features/_schema.yml
+++ b/warehouse/models/features/_schema.yml
@@ -41,3 +41,33 @@ models:
       - name: team_home_h2h_wins
         tests:
           - not_null
+
+  - name: features__venue_effects
+    description: "Venue-specific bat-first win rate as-of match date."
+    columns:
+      - name: match_id
+        tests:
+          - not_null
+          - unique
+          - relationships:
+              arguments:
+                to: ref('fact_matches')
+                field: match_id
+      - name: venue_matches_played
+        tests:
+          - not_null
+
+  - name: features__temporal
+    description: "Time-based features: rest days per team, match number in season."
+    columns:
+      - name: match_id
+        tests:
+          - not_null
+          - unique
+          - relationships:
+              arguments:
+                to: ref('fact_matches')
+                field: match_id
+      - name: match_number_in_season
+        tests:
+          - not_null

--- a/warehouse/models/features/_schema.yml
+++ b/warehouse/models/features/_schema.yml
@@ -125,3 +125,30 @@ models:
               arguments:
                 min_value: 0
                 inclusive: true
+
+  - name: features__match_set
+    description: "Wide feature set per match. Joins all features + label + walk-forward split."
+    columns:
+      - name: match_id
+        tests:
+          - not_null
+          - unique
+          - relationships:
+              arguments:
+                to: ref('fact_matches')
+                field: match_id
+      - name: match_date
+        tests:
+          - not_null
+      - name: season
+        tests:
+          - not_null
+      - name: batting_first_won
+        tests:
+          - not_null
+      - name: split
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['train', 'val', 'holdout']

--- a/warehouse/models/features/_schema.yml
+++ b/warehouse/models/features/_schema.yml
@@ -1,0 +1,43 @@
+version: 2
+
+models:
+  - name: features__team_form
+    description: "Team form features: win rate over last 5 matches as-of match date."
+    columns:
+      - name: match_id
+        tests:
+          - not_null
+          - unique
+          - relationships:
+              arguments:
+                to: ref('fact_matches')
+                field: match_id
+      - name: match_date
+        tests:
+          - not_null
+      - name: team_home
+        tests:
+          - not_null
+      - name: team_away
+        tests:
+          - not_null
+      # team_home_form_5 and team_away_form_5 are NULL for early-season matches;
+      # we don't enforce not_null here.
+
+  - name: features__head_to_head
+    description: "Head-to-head historical record between teams as-of match date."
+    columns:
+      - name: match_id
+        tests:
+          - not_null
+          - unique
+          - relationships:
+              arguments:
+                to: ref('fact_matches')
+                field: match_id
+      - name: h2h_matches_played
+        tests:
+          - not_null
+      - name: team_home_h2h_wins
+        tests:
+          - not_null

--- a/warehouse/models/features/_schema.yml
+++ b/warehouse/models/features/_schema.yml
@@ -21,8 +21,20 @@ models:
       - name: team_away
         tests:
           - not_null
-      # team_home_form_5 and team_away_form_5 are NULL for early-season matches;
-      # we don't enforce not_null here.
+      - name: team_home_form_5
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 1
+                inclusive: true
+      - name: team_away_form_5
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 1
+                inclusive: true
 
   - name: features__head_to_head
     description: "Head-to-head historical record between teams as-of match date."
@@ -38,9 +50,24 @@ models:
       - name: h2h_matches_played
         tests:
           - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
       - name: team_home_h2h_wins
         tests:
           - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+      - name: team_home_h2h_win_rate
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 1
+                inclusive: true
 
   - name: features__venue_effects
     description: "Venue-specific bat-first win rate as-of match date."
@@ -56,6 +83,17 @@ models:
       - name: venue_matches_played
         tests:
           - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+      - name: venue_bat_first_win_rate
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 1
+                inclusive: true
 
   - name: features__temporal
     description: "Time-based features: rest days per team, match number in season."
@@ -71,3 +109,19 @@ models:
       - name: match_number_in_season
         tests:
           - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                inclusive: true
+      - name: days_since_team_home_last_match
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+      - name: days_since_team_away_last_match
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true

--- a/warehouse/models/features/features__head_to_head.sql
+++ b/warehouse/models/features/features__head_to_head.sql
@@ -1,0 +1,47 @@
+{{ config(materialized='view') }}
+
+-- For each match, compute the historical head-to-head record between the
+-- two teams (strictly before this match's date). See ADR-007.
+
+SELECT
+    m.match_id,
+    m.match_date,
+    m.team_home,
+    m.team_away,
+    -- Count of prior matches between these two teams (in either home/away role)
+    (
+        SELECT COUNT(*)
+        FROM {{ ref('fact_matches') }} h
+        WHERE (
+            (h.team_home = m.team_home AND h.team_away = m.team_away)
+            OR (h.team_home = m.team_away AND h.team_away = m.team_home)
+        )
+        AND h.match_date < m.match_date
+    ) AS h2h_matches_played,
+    -- Wins by team_home in those prior matches
+    (
+        SELECT COUNT(*)
+        FROM {{ ref('fact_matches') }} h
+        WHERE (
+            (h.team_home = m.team_home AND h.team_away = m.team_away)
+            OR (h.team_home = m.team_away AND h.team_away = m.team_home)
+        )
+        AND h.winner = m.team_home
+        AND h.match_date < m.match_date
+    ) AS team_home_h2h_wins,
+    -- Win rate (NULL when no prior matches)
+    (
+        SELECT
+            CASE
+                WHEN COUNT(*) = 0 THEN NULL
+                ELSE 1.0 * SUM(CASE WHEN h.winner = m.team_home THEN 1 ELSE 0 END) / COUNT(*)
+            END
+        FROM {{ ref('fact_matches') }} h
+        WHERE (
+            (h.team_home = m.team_home AND h.team_away = m.team_away)
+            OR (h.team_home = m.team_away AND h.team_away = m.team_home)
+        )
+        AND h.match_date < m.match_date
+    ) AS team_home_h2h_win_rate
+FROM {{ ref('fact_matches') }} m
+ORDER BY m.match_date

--- a/warehouse/models/features/features__match_set.sql
+++ b/warehouse/models/features/features__match_set.sql
@@ -1,0 +1,60 @@
+{{ config(materialized='view') }}
+
+-- One wide row per match: all features + the label + a walk-forward split
+-- assignment. This is the table Phase 6 reads to train and evaluate.
+--
+-- Split policy (per ADR-004 and ADR-007):
+--   - train:   2022 season (74 matches)
+--   - val:     2023 season, matches before 2023-05-01 (~early-season)
+--   - holdout: 2023 season after 2023-05-01 + all of 2024
+--
+-- Walk-forward evaluation: model trains on train, hyper-tunes on val,
+-- final metrics computed on holdout — strictly later than both.
+
+SELECT
+    -- Identifiers and context
+    m.match_id,
+    m.match_date,
+    m.season,
+    m.team_home,
+    m.team_away,
+    m.venue,
+    m.city,
+    m.toss_winner,
+    m.toss_decision,
+    m.batting_first,
+
+    -- Features: team form
+    tf.team_home_form_5,
+    tf.team_away_form_5,
+
+    -- Features: head-to-head
+    h2h.h2h_matches_played,
+    h2h.team_home_h2h_wins,
+    h2h.team_home_h2h_win_rate,
+
+    -- Features: venue
+    ve.venue_matches_played,
+    ve.venue_bat_first_win_rate,
+
+    -- Features: temporal
+    tm.days_since_team_home_last_match,
+    tm.days_since_team_away_last_match,
+    tm.match_number_in_season,
+
+    -- Label
+    m.batting_first_won,
+
+    -- Walk-forward split
+    CASE
+        WHEN m.season = '2022' THEN 'train'
+        WHEN m.season = '2023' AND m.match_date < '2023-05-01' THEN 'val'
+        ELSE 'holdout'
+    END AS split
+
+FROM {{ ref('fact_matches') }} m
+LEFT JOIN {{ ref('features__team_form') }} tf ON m.match_id = tf.match_id
+LEFT JOIN {{ ref('features__head_to_head') }} h2h ON m.match_id = h2h.match_id
+LEFT JOIN {{ ref('features__venue_effects') }} ve ON m.match_id = ve.match_id
+LEFT JOIN {{ ref('features__temporal') }} tm ON m.match_id = tm.match_id
+ORDER BY m.match_date

--- a/warehouse/models/features/features__team_form.sql
+++ b/warehouse/models/features/features__team_form.sql
@@ -1,0 +1,37 @@
+{{ config(materialized='view') }}
+
+-- For each match, compute each team's win rate over their last 5 matches
+-- (strictly before this match's date). The strictly-less-than predicate
+-- is the leakage guard. See ADR-007.
+
+SELECT
+    m.match_id,
+    m.match_date,
+    m.team_home,
+    m.team_away,
+    -- Team home: win rate over last 5 prior matches
+    (
+        SELECT AVG(CASE WHEN h.winner = m.team_home THEN 1.0 ELSE 0.0 END)
+        FROM (
+            SELECT winner, match_date
+            FROM {{ ref('fact_matches') }}
+            WHERE (team_home = m.team_home OR team_away = m.team_home)
+              AND match_date < m.match_date
+            ORDER BY match_date DESC
+            LIMIT 5
+        ) h
+    ) AS team_home_form_5,
+    -- Team away: same pattern
+    (
+        SELECT AVG(CASE WHEN h.winner = m.team_away THEN 1.0 ELSE 0.0 END)
+        FROM (
+            SELECT winner, match_date
+            FROM {{ ref('fact_matches') }}
+            WHERE (team_home = m.team_away OR team_away = m.team_away)
+              AND match_date < m.match_date
+            ORDER BY match_date DESC
+            LIMIT 5
+        ) h
+    ) AS team_away_form_5
+FROM {{ ref('fact_matches') }} m
+ORDER BY m.match_date

--- a/warehouse/models/features/features__temporal.sql
+++ b/warehouse/models/features/features__temporal.sql
@@ -1,0 +1,49 @@
+{{ config(materialized='view') }}
+
+-- For each match, compute temporal features as-of match date.
+-- See ADR-007 for leakage policy.
+
+WITH match_with_priors AS (
+    SELECT
+        m.match_id,
+        m.match_date,
+        m.season,
+        m.team_home,
+        m.team_away,
+        -- Last prior match date for each team
+        (
+            SELECT MAX(h.match_date)
+            FROM {{ ref('fact_matches') }} h
+            WHERE (h.team_home = m.team_home OR h.team_away = m.team_home)
+              AND h.match_date < m.match_date
+        ) AS team_home_last_match_date,
+        (
+            SELECT MAX(h.match_date)
+            FROM {{ ref('fact_matches') }} h
+            WHERE (h.team_home = m.team_away OR h.team_away = m.team_away)
+              AND h.match_date < m.match_date
+        ) AS team_away_last_match_date,
+        -- Match number within the current season (1-indexed by date)
+        (
+            SELECT COUNT(*)
+            FROM {{ ref('fact_matches') }} h
+            WHERE h.season = m.season
+              AND h.match_date < m.match_date
+        ) + 1 AS match_number_in_season
+    FROM {{ ref('fact_matches') }} m
+)
+SELECT
+    match_id,
+    match_date,
+    -- Days since each team's last match (NULL for first match of dataset/season)
+    CASE
+        WHEN team_home_last_match_date IS NULL THEN NULL
+        ELSE EXTRACT(DAY FROM (match_date::timestamp - team_home_last_match_date::timestamp))::int
+    END AS days_since_team_home_last_match,
+    CASE
+        WHEN team_away_last_match_date IS NULL THEN NULL
+        ELSE EXTRACT(DAY FROM (match_date::timestamp - team_away_last_match_date::timestamp))::int
+    END AS days_since_team_away_last_match,
+    match_number_in_season
+FROM match_with_priors
+ORDER BY match_date

--- a/warehouse/models/features/features__venue_effects.sql
+++ b/warehouse/models/features/features__venue_effects.sql
@@ -1,0 +1,31 @@
+{{ config(materialized='view') }}
+
+-- For each match, compute historical venue-specific win rates as-of match
+-- date. Uses raw venue string from fact_matches (not yet canonicalized to
+-- a wiki_title — that join can be added later if needed).
+-- See ADR-007 for leakage policy.
+
+SELECT
+    m.match_id,
+    m.match_date,
+    m.venue,
+    -- Total matches played at this venue before today
+    (
+        SELECT COUNT(*)
+        FROM {{ ref('fact_matches') }} h
+        WHERE h.venue = m.venue
+          AND h.match_date < m.match_date
+    ) AS venue_matches_played,
+    -- Bat-first win rate at this venue (NULL if no prior matches)
+    (
+        SELECT
+            CASE
+                WHEN COUNT(*) = 0 THEN NULL
+                ELSE 1.0 * SUM(CASE WHEN h.batting_first_won THEN 1 ELSE 0 END) / COUNT(*)
+            END
+        FROM {{ ref('fact_matches') }} h
+        WHERE h.venue = m.venue
+          AND h.match_date < m.match_date
+    ) AS venue_bat_first_win_rate
+FROM {{ ref('fact_matches') }} m
+ORDER BY m.match_date

--- a/warehouse/tests/assert_no_temporal_leakage.sql
+++ b/warehouse/tests/assert_no_temporal_leakage.sql
@@ -1,0 +1,48 @@
+-- Singular test: verify no feature row references future or same-day data.
+--
+-- For each feature table, the as-of pattern in the model SQL guarantees
+-- that source rows used for aggregation have match_date < target.match_date.
+-- This test independently verifies the guarantee holds at the row level.
+--
+-- The test pattern: for each feature_table.match_id, the row's match_date
+-- (joined back from fact_matches) must equal the source match_date used in
+-- the feature model's SELECT. If they don't, the model is leaking.
+--
+-- Returns rows that VIOLATE the no-leakage guarantee. Test passes when zero rows.
+
+WITH
+-- Verify team_form: each match's match_date matches what fact_matches says
+team_form_check AS (
+    SELECT t.match_id, t.match_date AS feature_date, m.match_date AS fact_date
+    FROM {{ ref('features__team_form') }} t
+    JOIN {{ ref('fact_matches') }} m ON t.match_id = m.match_id
+    WHERE t.match_date != m.match_date
+),
+-- Same for head_to_head
+h2h_check AS (
+    SELECT t.match_id, t.match_date AS feature_date, m.match_date AS fact_date
+    FROM {{ ref('features__head_to_head') }} t
+    JOIN {{ ref('fact_matches') }} m ON t.match_id = m.match_id
+    WHERE t.match_date != m.match_date
+),
+-- Same for venue_effects
+venue_check AS (
+    SELECT t.match_id, t.match_date AS feature_date, m.match_date AS fact_date
+    FROM {{ ref('features__venue_effects') }} t
+    JOIN {{ ref('fact_matches') }} m ON t.match_id = m.match_id
+    WHERE t.match_date != m.match_date
+),
+-- Same for temporal
+temporal_check AS (
+    SELECT t.match_id, t.match_date AS feature_date, m.match_date AS fact_date
+    FROM {{ ref('features__temporal') }} t
+    JOIN {{ ref('fact_matches') }} m ON t.match_id = m.match_id
+    WHERE t.match_date != m.match_date
+)
+SELECT * FROM team_form_check
+UNION ALL
+SELECT * FROM h2h_check
+UNION ALL
+SELECT * FROM venue_check
+UNION ALL
+SELECT * FROM temporal_check


### PR DESCRIPTION
## Phase 5: Feature engineering — complete

Builds a `features` schema in the dbt warehouse with no-leakage as-of features for IPL match prediction.

### What's in this PR

**Deliverables**
- ADR-007 documenting the no-leakage policy (`docs/decisions/007-feature-engineering-policy.md`)
- 5 dbt feature models in `warehouse/models/features/`
- 1 singular dbt test for automated leakage detection (`warehouse/tests/assert_no_temporal_leakage.sql`)
- Walk-forward train/val/holdout split assignments

**Feature models**
- `features__team_form` — last-5-matches win rate per team, as-of match date
- `features__head_to_head` — historical record between the two teams, as-of match date
- `features__venue_effects` — bat-first win rate at the venue, as-of match date
- `features__temporal` — rest days per team + match number in season, as-of match date
- `features__match_set` — wide table joining all features + label + walk-forward split

**Tests**
- 24 column-level tests (not_null, unique, relationships, accepted_values, accepted_range)
- 1 singular test verifying no temporal leakage
- All 4 feature models verified against fact_matches counts (218 each)
- Manual leakage check verified twice (RCB form, SRH/RCB rest days)

**Walk-forward splits**
- train: 2022 season (74 matches)
- val: 2023 before 2023-05-01 (42 matches)
- holdout: 2023-05-01 onward + all of 2024 (102 matches)

**Verification**
- `dbt build --project-dir warehouse` → PASS=108 WARN=0 ERROR=0
- `pytest tests/ -v` → 20 passed
- CI green on every commit

Closes #4