### PR TITLE
Phase 7 hotfix: add dbt deps step before dbt build in CI

### DIFF
--- a/.github/workflows/weekly_pipeline.yml
+++ b/.github/workflows/weekly_pipeline.yml
@@ -98,6 +98,9 @@ jobs:
         run: python -m ingestion.cricketdata.fixtures_parser
 
       # --- Warehouse build (dbt models: silver, gold, features) ---
+      - name: dbt deps
+        run: dbt deps --project-dir warehouse
+
       - name: dbt build
         run: dbt build --project-dir warehouse
 


### PR DESCRIPTION
First weekly_pipeline run failed because the CI environment doesn't have dbt_packages/ pre-populated. This adds a `dbt deps` step before `dbt build`.

Verified locally; will trigger weekly_pipeline manually after merge.